### PR TITLE
Vision Changes From the Season to PoseEstimator-Master (pending)

### DIFF
--- a/src/main/java/frc/constants/VisionConstants.java
+++ b/src/main/java/frc/constants/VisionConstants.java
@@ -10,10 +10,6 @@ import java.io.IOException;
 
 public class VisionConstants {
 
-	public static final String FILTERED_DATA_LOGPATH_ADDITION = "FilteredData/";
-
-	public static final String NON_FILTERED_DATA_LOGPATH_ADDITION = "NonFilteredData/";
-
 	public static final String VISION_SOURCE_LOGPATH_ADDITION = "VisionSource/";
 
 	public static final String MULTI_VISION_SOURCES_LOGPATH = "MultiVisionSources/";

--- a/src/main/java/frc/robot/vision/VisionFilters.java
+++ b/src/main/java/frc/robot/vision/VisionFilters.java
@@ -2,65 +2,93 @@ package frc.robot.vision;
 
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Rotation2d;
+import frc.constants.VisionConstants;
 import frc.constants.field.Field;
 import frc.robot.vision.data.AprilTagVisionData;
+import frc.robot.vision.data.LimeLightAprilTagVisionData;
 import frc.robot.vision.data.VisionData;
+import frc.robot.vision.sources.limelights.LimelightPoseEstimationMethod;
 import frc.utils.Filter;
 import frc.utils.math.ToleranceMath;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 public class VisionFilters {
 
+	public static Filter<VisionData> isDataFromMegaTag2() {
+		return (visionData) -> visionData instanceof LimeLightAprilTagVisionData limelightVisionData
+			&& limelightVisionData.getPoseEstimationMethod() == LimelightPoseEstimationMethod.MEGATAG_2;
+	}
+
 	public static Filter<VisionData> isRollAtAngle(Rotation2d wantedRoll, Rotation2d rollTolerance) {
-		return new Filter<>(
-			visionData -> ToleranceMath
-				.isNearWrapped(wantedRoll, Rotation2d.fromRadians(visionData.getEstimatedPose().getRotation().getX()), rollTolerance)
-		);
+		return (visionData) -> ToleranceMath
+			.isNearWrapped(wantedRoll, Rotation2d.fromRadians(visionData.getEstimatedPose().getRotation().getX()), rollTolerance);
 	}
 
 	public static Filter<VisionData> isPitchAtAngle(Rotation2d wantedPitch, Rotation2d pitchTolerance) {
-		return new Filter<>(
-			visionData -> ToleranceMath
-				.isNearWrapped(wantedPitch, Rotation2d.fromRadians(visionData.getEstimatedPose().getRotation().getY()), pitchTolerance)
-		);
+		return (visionData) -> ToleranceMath
+			.isNearWrapped(wantedPitch, Rotation2d.fromRadians(visionData.getEstimatedPose().getRotation().getY()), pitchTolerance);
 	}
 
-	public static Filter<VisionData> isYawAtAngle(Supplier<Rotation2d> wantedYawSupplier, Rotation2d yawTolerance) {
-		return new Filter<>(
-			visionData -> ToleranceMath
-				.isNearWrapped(wantedYawSupplier.get(), Rotation2d.fromRadians(visionData.getEstimatedPose().getRotation().getZ()), yawTolerance)
-		);
+	public static Filter<VisionData> isYawAtAngle(Supplier<Optional<Rotation2d>> wantedYawSupplier, Rotation2d yawTolerance) {
+		return (visionData) -> wantedYawSupplier.get()
+			.map(
+				wantedAngle -> ToleranceMath
+					.isNearWrapped(wantedAngle, Rotation2d.fromRadians(visionData.getEstimatedPose().getRotation().getZ()), yawTolerance)
+			)
+			.orElse(false);
+	}
+
+	public static Filter<VisionData> isYawAtAngleForMegaTag2(Supplier<Optional<Rotation2d>> wantedYawSupplier, Rotation2d yawTolerance) {
+		return isDataFromMegaTag2().implies(isYawAtAngle(wantedYawSupplier, yawTolerance));
+	}
+
+	/**
+	 * A Filter that filters the random noise in MegaTag2 that causes the yaw angle to be exactly 0.
+	 */
+	public static Filter<VisionData> isYawAngleNotZero() {
+		return (visionData) -> visionData.getEstimatedPose().getRotation().getZ() != 0.0;
+	}
+
+	public static Filter<VisionData> isYawAngleNotZeroForMegaTag2() {
+		return isDataFromMegaTag2().implies(isYawAngleNotZero());
 	}
 
 	public static Filter<VisionData> isOnGround(double distanceFromGroundToleranceMeters) {
-		return new Filter<>(visionData -> MathUtil.isNear(0, visionData.getEstimatedPose().getZ(), distanceFromGroundToleranceMeters));
+		return (visionData) -> MathUtil.isNear(0, visionData.getEstimatedPose().getZ(), distanceFromGroundToleranceMeters);
 	}
 
 	public static Filter<AprilTagVisionData> isAprilTagHeightValid(double aprilTagHeightToleranceMeters) {
-		return new Filter<>(
-			aprilTagVisionData -> MathUtil.isNear(
-				VisionUtils.getAprilTagHeightByID(aprilTagVisionData.getTrackedAprilTagId()),
-				aprilTagVisionData.getAprilTagHeightMeters(),
-				aprilTagHeightToleranceMeters
-			)
+		return aprilTagVisionData -> MathUtil.isNear(
+			VisionUtils.getAprilTagHeightByID(aprilTagVisionData.getTrackedAprilTagId()),
+			aprilTagVisionData.getAprilTagHeightMeters(),
+			aprilTagHeightToleranceMeters
 		);
 	}
 
 	public static Filter<VisionData> isXInField(double xToleranceMeters) {
-		return new Filter<>(
-			visionData -> ToleranceMath.isInRange(visionData.getEstimatedPose().getX(), 0, Field.LENGTH_METERS, xToleranceMeters)
-		);
+		return (visionData) -> ToleranceMath.isInRange(visionData.getEstimatedPose().getX(), 0, Field.LENGTH_METERS, xToleranceMeters);
 	}
 
 	public static Filter<VisionData> isYInField(double yToleranceMeters) {
-		return new Filter<>(
-			visionData -> ToleranceMath.isInRange(visionData.getEstimatedPose().getY(), 0, Field.WIDTH_METERS, yToleranceMeters)
-		);
+		return (visionData) -> ToleranceMath.isInRange(visionData.getEstimatedPose().getY(), 0, Field.WIDTH_METERS, yToleranceMeters);
 	}
 
 	public static Filter<VisionData> isInField(double positionToleranceMeters) {
 		return isXInField(positionToleranceMeters).and(isYInField(positionToleranceMeters));
+	}
+
+	public static Filter<AprilTagVisionData> isSeeingTag(int tagID) {
+		return (visionData) -> visionData.getTrackedAprilTagId() == tagID;
+	}
+
+	public static Filter<AprilTagVisionData> isNotSeeingTags(int... tags) {
+		Filter<AprilTagVisionData> filter = isSeeingTag(VisionConstants.NO_APRILTAG_ID);
+		for (int id : tags) {
+			filter = filter.or(isSeeingTag(id));
+		}
+		return filter.not();
 	}
 
 }

--- a/src/main/java/frc/robot/vision/data/AprilTagVisionData.java
+++ b/src/main/java/frc/robot/vision/data/AprilTagVisionData.java
@@ -26,19 +26,19 @@ public class AprilTagVisionData extends VisionData {
 		this.aprilTagId = aprilTagId;
 	}
 
-	public StandardDeviations3D getStandardDeviations() {
+	public final StandardDeviations3D getStandardDeviations() {
 		return standardDeviations;
 	}
 
-	public double getAprilTagHeightMeters() {
+	public final double getAprilTagHeightMeters() {
 		return aprilTagHeightMeters;
 	}
 
-	public double getDistanceFromAprilTagMeters() {
+	public final double getDistanceFromAprilTagMeters() {
 		return distanceFromAprilTagMeters;
 	}
 
-	public int getTrackedAprilTagId() {
+	public final int getTrackedAprilTagId() {
 		return aprilTagId;
 	}
 

--- a/src/main/java/frc/robot/vision/data/LimeLightAprilTagVisionData.java
+++ b/src/main/java/frc/robot/vision/data/LimeLightAprilTagVisionData.java
@@ -1,0 +1,29 @@
+package frc.robot.vision.data;
+
+import edu.wpi.first.math.geometry.Pose3d;
+import frc.robot.vision.sources.limelights.LimelightPoseEstimationMethod;
+import frc.utils.math.StandardDeviations3D;
+
+public final class LimeLightAprilTagVisionData extends AprilTagVisionData {
+
+	private final LimelightPoseEstimationMethod poseEstimationMethod;
+
+	public LimeLightAprilTagVisionData(
+		String sourceName,
+		Pose3d estimatedRobotPosition,
+		double timestamp,
+		StandardDeviations3D standardDeviations,
+		double aprilTagHeightMeters,
+		double distanceFromAprilTagMeters,
+		int aprilTagId,
+		LimelightPoseEstimationMethod poseEstimationMethod
+	) {
+		super(sourceName, estimatedRobotPosition, timestamp, standardDeviations, aprilTagHeightMeters, distanceFromAprilTagMeters, aprilTagId);
+		this.poseEstimationMethod = poseEstimationMethod;
+	}
+
+	public final LimelightPoseEstimationMethod getPoseEstimationMethod() {
+		return poseEstimationMethod;
+	}
+
+}

--- a/src/main/java/frc/robot/vision/data/VisionData.java
+++ b/src/main/java/frc/robot/vision/data/VisionData.java
@@ -14,15 +14,15 @@ public class VisionData {
 		this.timestamp = timestamp;
 	}
 
-	public String getSourceName() {
+	public final String getSourceName() {
 		return sourceName;
 	}
 
-	public Pose3d getEstimatedPose() {
+	public final Pose3d getEstimatedPose() {
 		return estimatedPose;
 	}
 
-	public double getTimestamp() {
+	public final double getTimestamp() {
 		return timestamp;
 	}
 

--- a/src/main/java/frc/robot/vision/multivisionsources/MultiAprilTagVisionSources.java
+++ b/src/main/java/frc/robot/vision/multivisionsources/MultiAprilTagVisionSources.java
@@ -1,5 +1,6 @@
 package frc.robot.vision.multivisionsources;
 
+import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
@@ -132,18 +133,20 @@ public class MultiAprilTagVisionSources extends MultiVisionSources<AprilTagVisio
 	}
 
 	private void logAprilTagPoseData() {
+		List<Integer> seenApriltagIDs = new ArrayList<>();
 		for (AprilTagVisionData visionData : getUnfilteredVisionData()) {
 			int aprilTagID = visionData.getTrackedAprilTagId();
 			Optional<Pose3d> aprilTag = VisionConstants.APRIL_TAG_FIELD_LAYOUT.getTagPose(aprilTagID);
-			aprilTag.ifPresent((pose) -> Logger.recordOutput(logPath + "targets/" + aprilTagID, pose));
+			aprilTag.ifPresent((pose) -> {
+				Logger.recordOutput(logPath + "targets/" + aprilTagID, pose);
+				seenApriltagIDs.add(aprilTagID);
+			});
 		}
-	}
-
-	@Override
-	public void log() {
-		super.log();
-		logAprilTagPoseData();
-		Logger.recordOutput(logPath + "inputtedRobotHeading", robotHeadingSupplier.get());
+		for (int aprilTagID = 1; aprilTagID <= VisionConstants.APRIL_TAG_FIELD_LAYOUT.getTags().size(); aprilTagID++) {
+			if (!seenApriltagIDs.contains(aprilTagID)) {
+				Logger.recordOutput(logPath + "targets/" + aprilTagID, Pose2d.kZero);
+			}
+		}
 	}
 
 }

--- a/src/main/java/frc/robot/vision/multivisionsources/MultiVisionSources.java
+++ b/src/main/java/frc/robot/vision/multivisionsources/MultiVisionSources.java
@@ -1,6 +1,5 @@
 package frc.robot.vision.multivisionsources;
 
-import frc.constants.VisionConstants;
 import frc.robot.vision.data.VisionData;
 import frc.robot.vision.sources.VisionSource;
 import frc.utils.Filter;
@@ -48,8 +47,9 @@ public class MultiVisionSources<T extends VisionData> {
 	}
 
 	public void log() {
-		logPoses(logPath + VisionConstants.FILTERED_DATA_LOGPATH_ADDITION, getFilteredVisionData());
-		logPoses(logPath + VisionConstants.NON_FILTERED_DATA_LOGPATH_ADDITION, getUnfilteredVisionData());
+		for (VisionSource<T> visionSource : visionSources) {
+			visionSource.log();
+		}
 	}
 
 	protected static <T extends VisionData> ArrayList<T> createMappedCopyOfSources(

--- a/src/main/java/frc/robot/vision/sources/VisionSource.java
+++ b/src/main/java/frc/robot/vision/sources/VisionSource.java
@@ -8,7 +8,11 @@ import java.util.function.Function;
 
 public interface VisionSource<T extends VisionData> {
 
+	String getName();
+
 	void update();
+
+	void log();
 
 	Optional<T> getVisionData();
 

--- a/src/main/java/frc/robot/vision/sources/limelights/DynamicSwitchingLimelight.java
+++ b/src/main/java/frc/robot/vision/sources/limelights/DynamicSwitchingLimelight.java
@@ -19,6 +19,7 @@ import java.util.Optional;
  */
 public class DynamicSwitchingLimelight implements IndpendentHeadingVisionSource, RobotHeadingRequiringVisionSource {
 
+	private final String sourceName;
 	private final IndpendentHeadingVisionSource independentPoseEstimatingLimelight;
 	private final RobotHeadingRequiringVisionSource headingRequiringLimelight;
 	private boolean useGyroForPoseEstimating;
@@ -31,6 +32,7 @@ public class DynamicSwitchingLimelight implements IndpendentHeadingVisionSource,
 		Filter<? super AprilTagVisionData> filter,
 		Pose3d cameraPoseOffset
 	) {
+		this.sourceName = sourceName;
 		this.useGyroForPoseEstimating = defaultUseGyroForPoseEstimating;
 		this.independentPoseEstimatingLimelight = LimelightFactory.createRobotHeadingEstimatingLimelight(
 			cameraNetworkTablesName,
@@ -50,6 +52,11 @@ public class DynamicSwitchingLimelight implements IndpendentHeadingVisionSource,
 
 	public void setUseRobotHeadingForPoseEstimating(boolean useGyroForPoseEstimating) {
 		this.useGyroForPoseEstimating = useGyroForPoseEstimating;
+	}
+
+	@Override
+	public String getName() {
+		return sourceName;
 	}
 
 	@Override
@@ -94,6 +101,11 @@ public class DynamicSwitchingLimelight implements IndpendentHeadingVisionSource,
 	@Override
 	public void updateRobotAngleValues(RobotAngleValues robotAngleValues) {
 		headingRequiringLimelight.updateRobotAngleValues(robotAngleValues);
+	}
+
+	public void log() {
+		independentPoseEstimatingLimelight.log();
+		headingRequiringLimelight.log();
 	}
 
 }

--- a/src/main/java/frc/robot/vision/sources/limelights/LimeLightSource.java
+++ b/src/main/java/frc/robot/vision/sources/limelights/LimeLightSource.java
@@ -5,14 +5,15 @@ import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import frc.robot.poseestimator.Pose3dComponentsValue;
-import frc.utils.math.StandardDeviations3D;
 import frc.constants.VisionConstants;
+import frc.robot.poseestimator.Pose3dComponentsValue;
+import frc.robot.vision.data.LimeLightAprilTagVisionData;
+import frc.utils.AngleUnit;
+import frc.utils.math.StandardDeviations3D;
 import frc.robot.vision.RobotAngleValues;
 import frc.robot.vision.data.AprilTagVisionData;
 import frc.robot.vision.sources.IndpendentHeadingVisionSource;
 import frc.robot.vision.sources.RobotHeadingRequiringVisionSource;
-import frc.utils.AngleUnit;
 import frc.utils.Conversions;
 import frc.utils.Filter;
 import frc.utils.pose.PoseUtil;
@@ -22,6 +23,7 @@ import frc.utils.alerts.PeriodicAlert;
 import frc.utils.time.TimeUtil;
 import org.littletonrobotics.junction.Logger;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.BooleanSupplier;
 
@@ -84,14 +86,18 @@ public class LimeLightSource implements IndpendentHeadingVisionSource, RobotHead
 
 		updateCameraPoseOffset(cameraPoseOffset);
 		update();
-		log();
+	}
+
+	@Override
+	public String getName() {
+		return sourceName;
 	}
 
 	@Override
 	public void update() {
 		lastSeenAprilTagId = getAprilTagID();
 		robotOrientationEntry.setDoubleArray(robotAngleValues.asArray());
-		Logger.recordOutput(logPath + "gyroAngleValues", robotAngleValues.asArray());
+//		Logger.recordOutput(logPath + "gyroAngleValues", robotAngleValues.asArray());
 		aprilTagPoseArray = aprilTagPoseEntry.getDoubleArray(new double[VisionConstants.LIMELIGHT_ENTRY_ARRAY_LENGTH]);
 		NetworkTableEntry entry = switch (poseEstimationMethod) {
 			case MEGATAG_1 -> robotPoseEntryMegaTag1;
@@ -101,8 +107,6 @@ public class LimeLightSource implements IndpendentHeadingVisionSource, RobotHead
 		standardDeviationsArray = standardDeviations.getDoubleArray(new double[Pose3dComponentsValue.POSE3D_COMPONENTS_AMOUNT]);
 		computingPipeLineLatency = computingPipelineLatencyEntry.getDouble(0D);
 		captureLatency = captureLatencyEntry.getDouble(0D);
-
-		log();
 	}
 
 	protected double getLatency() {
@@ -150,14 +154,23 @@ public class LimeLightSource implements IndpendentHeadingVisionSource, RobotHead
 	public Optional<AprilTagVisionData> getVisionData() {
 		Optional<Pair<Pose3d, Double>> poseEstimation = getUpdatedPose3DEstimation();
 		return poseEstimation.map(
-			pose3dDoublePair -> new AprilTagVisionData(
-				sourceName,
+			pose3dDoublePair -> new LimeLightAprilTagVisionData(
+				getName(),
 				pose3dDoublePair.getFirst(),
 				pose3dDoublePair.getSecond(),
-				new StandardDeviations3D(standardDeviationsArray),
+				new StandardDeviations3D(
+					poseEstimationMethod.equals(LimelightPoseEstimationMethod.MEGATAG_1)
+						? Arrays.copyOfRange(standardDeviationsArray, 0, Pose3dComponentsValue.values().length)
+						: Arrays.copyOfRange(
+							standardDeviationsArray,
+							Pose3dComponentsValue.values().length,
+							2 * Pose3dComponentsValue.values().length
+						)
+				),
 				getAprilTagValueInRobotSpace(Pose3dComponentsValue.Z_VALUE),
 				getDistanceFromTag(),
-				lastSeenAprilTagId
+				lastSeenAprilTagId,
+				getPoseEstimationMethod()
 			)
 		);
 	}
@@ -191,6 +204,10 @@ public class LimeLightSource implements IndpendentHeadingVisionSource, RobotHead
 		this.robotAngleValues = robotAngleValues;
 	}
 
+	public LimelightPoseEstimationMethod getPoseEstimationMethod() {
+		return poseEstimationMethod;
+	}
+
 	private void updateCameraPoseOffset(Pose3d cameraPoseOffset) {
 		this.cameraPoseOffsetEntry.setDoubleArray(PoseUtil.pose3DToPoseArray(cameraPoseOffset, AngleUnit.DEGREES));
 	}
@@ -205,16 +222,11 @@ public class LimeLightSource implements IndpendentHeadingVisionSource, RobotHead
 
 	public void log() {
 		Logger.recordOutput(logPath + "filterResult", shouldDataBeFiltered.getAsBoolean());
-		Logger.recordOutput(logPath + "megaTagDirectOutput", PoseUtil.toPose3D(robotPoseArray, AngleUnit.DEGREES));
 		getVisionData().ifPresent(visionData -> {
 			Logger.recordOutput(logPath + "unfiltered3DVision", visionData.getEstimatedPose());
-			Logger.recordOutput(logPath + "unfiltered2DVision(Projected)", visionData.getEstimatedPose().toPose2d());
 			Logger.recordOutput(logPath + "aprilTagHeightMeters", visionData.getAprilTagHeightMeters());
 			Logger.recordOutput(logPath + "lastUpdate", visionData.getTimestamp());
 			Logger.recordOutput(logPath + "stdDevs", standardDeviationsArray);
-			if (poseEstimationMethod == LimelightPoseEstimationMethod.MEGATAG_1) {
-				Logger.recordOutput(logPath + "robotMegaTag1Heading", visionData.getEstimatedPose().getRotation().toRotation2d());
-			}
 		});
 	}
 

--- a/src/main/java/frc/robot/vision/sources/limelights/LimeLightSource.java
+++ b/src/main/java/frc/robot/vision/sources/limelights/LimeLightSource.java
@@ -97,7 +97,6 @@ public class LimeLightSource implements IndpendentHeadingVisionSource, RobotHead
 	public void update() {
 		lastSeenAprilTagId = getAprilTagID();
 		robotOrientationEntry.setDoubleArray(robotAngleValues.asArray());
-//		Logger.recordOutput(logPath + "gyroAngleValues", robotAngleValues.asArray());
 		aprilTagPoseArray = aprilTagPoseEntry.getDoubleArray(new double[VisionConstants.LIMELIGHT_ENTRY_ARRAY_LENGTH]);
 		NetworkTableEntry entry = switch (poseEstimationMethod) {
 			case MEGATAG_1 -> robotPoseEntryMegaTag1;
@@ -228,6 +227,7 @@ public class LimeLightSource implements IndpendentHeadingVisionSource, RobotHead
 			Logger.recordOutput(logPath + "lastUpdate", visionData.getTimestamp());
 			Logger.recordOutput(logPath + "stdDevs", standardDeviationsArray);
 		});
+		Logger.recordOutput(logPath + "gyroAngleValues", robotAngleValues.asArray());
 	}
 
 }

--- a/src/main/java/frc/utils/Filter.java
+++ b/src/main/java/frc/utils/Filter.java
@@ -1,29 +1,44 @@
 package frc.utils;
 
-import java.util.function.Function;
 
-public class Filter<T> {
+public interface Filter<T> {
 
-	private final Function<T, Boolean> filter;
-
-	public Filter(Function<T, Boolean> filter) {
-		this.filter = filter;
+	static <T> Filter<T> nonFilteringFilter() {
+		return data -> true;
 	}
 
-	public static <T> Filter<T> nonFilteringFilter() {
-		return new Filter<>(data -> true);
+	boolean apply(T data);
+
+	default Filter<T> not() {
+		return data -> !apply(data);
 	}
 
-	public boolean apply(T data) {
-		return filter.apply(data);
+	default <E extends T> Filter<E> and(Filter<E> otherFilter) {
+		return data -> apply(data) && otherFilter.apply(data);
 	}
 
-	public Filter<T> and(Filter<T> otherFilter) {
-		return new Filter<>(data -> apply(data) && otherFilter.apply(data));
+	default <E extends T> Filter<E> or(Filter<E> otherFilter) {
+		return data -> apply(data) || otherFilter.apply(data);
 	}
 
-	public Filter<T> or(Filter<T> otherFilter) {
-		return new Filter<>(data -> apply(data) || otherFilter.apply(data));
+	default <E extends T> Filter<E> xor(Filter<E> otherFilter) {
+		return data -> apply(data) ^ otherFilter.apply(data);
+	}
+
+	default <E extends T> Filter<E> nand(Filter<E> otherFilter) {
+		return data -> and(otherFilter).not().apply(data);
+	}
+
+	default <E extends T> Filter<E> nor(Filter<E> otherFilter) {
+		return data -> or(otherFilter).not().apply(data);
+	}
+
+	default <E extends T> Filter<E> xnor(Filter<E> otherFilter) {
+		return data -> xor(otherFilter).not().apply(data);
+	}
+
+	default <E extends T> Filter<E> implies(Filter<E> otherFilter) {
+		return data -> !apply(data) || otherFilter.apply(data);
 	}
 
 }


### PR DESCRIPTION
### This PR is Pending for PPv2.0 to be merged in order to get into Master. Please consider reviewing https://github.com/GreenBlitz/GB-Robot-Template/pull/630 before reviewing this PR

This PR includes the following changes: 
- Filter<T> as a functional interface
- More VisionFilters (thanks to @GilStein1)
- Limelights now send inside its VisionData the PoseEstimating method
- VisionData includes the source's name
- [not from the season] log() is now part of the VisionSource interface, and MultiVisionSources delegates it instead of preforming its own logging. This means sources does not automatically logs its data, and the runtime cost of logging could be measured separately of general source updates

The following changes from the season are *not* included in this PR and still waiting to get merged: 
- HeadingEstimator improvements
- (optional) some constants, including the default vision filter
- improved OdometryData performance (thank to @YHerm)
- Other PP changes